### PR TITLE
Mass Assignment Security using ActiveModel::MassAssignmentSecurity

### DIFF
--- a/dm-rails.gemspec
+++ b/dm-rails.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
      "dm-rails.gemspec",
      "lib/dm-rails.rb",
      "lib/dm-rails/configuration.rb",
+     "lib/dm-rails/mass_assignment_security.rb",
      "lib/dm-rails/middleware/identity_map.rb",
      "lib/dm-rails/railtie.rb",
      "lib/dm-rails/railties/controller_runtime.rb",

--- a/lib/dm-rails/mass_assignment_security.rb
+++ b/lib/dm-rails/mass_assignment_security.rb
@@ -1,0 +1,66 @@
+require 'dm-core'
+require 'active_support/core_ext/class/attribute'
+require 'active_support/concern'
+require 'active_model'
+
+module ActiveModel
+  module MassAssignmentSecurity
+    module Sanitizer
+      # Returns all attributes not denied by the authorizer. Property keys can
+      # be a Symbol, String, DataMapper::Property, or DataMapper::Relationship
+      def sanitize(attributes)
+        sanitized_attributes = attributes.reject do |key, value|
+          key_name = key.name rescue key
+          deny?(key_name)
+        end
+        debug_protected_attribute_removal(attributes, sanitized_attributes)
+        sanitized_attributes
+      end
+    end
+  end
+end
+
+module Rails
+  module DataMapper
+    # = Active Model Mass-Assignment Security
+    module MassAssignmentSecurity
+      extend ::ActiveSupport::Concern
+      include ::ActiveModel::MassAssignmentSecurity
+
+      module ClassMethods
+        extend ::ActiveModel::MassAssignmentSecurity::ClassMethods
+
+        def logger
+          @logger ||= ::DataMapper.logger
+        end
+
+      end
+
+      # Allows you to set all the attributes at once by passing in a hash with keys
+      # matching the attribute names (which again matches the column names).
+      #
+      # If +guard_protected_attributes+ is true (the default), then sensitive
+      # attributes can be protected from this form of mass-assignment by using
+      # the +attr_protected+ macro. Or you can alternatively specify which
+      # attributes *can* be accessed with the +attr_accessible+ macro. Then all the
+      # attributes not included in that won't be allowed to be mass-assigned.
+      #
+      #   class User < ActiveRecord::Base
+      #     attr_protected :is_admin
+      #   end
+      #
+      #   user = User.new
+      #   user.attributes = { :username => 'Phusion', :is_admin => true }
+      #   user.username   # => "Phusion"
+      #   user.is_admin?  # => false
+      #
+      #   user.send(:attributes=, { :username => 'Phusion', :is_admin => true }, false)
+      #   user.is_admin?  # => true
+      def attributes=(attributes, guard_protected_attributes = true)
+        attributes = sanitize_for_mass_assignment(attributes) if guard_protected_attributes
+        super(attributes)
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
I've added mass assignment protection via ActiveModel. This can be used exactly the same as Rails + ActiveRecord using attr_accessible and attr_protected.

Currently, I'm able to use this via the following:

```
require 'dm-rails/mass_assignment_security'
DataMapper::Model.append_inclusions(Rails::DataMapper::MassAssignmentSecurity)
```

Alternatively, you can include Rails::DataMapper::MassAssignmentSecurity into any model. As my next step, I would like to integrate this into an application.rb config block. I'm open to suggestions or advice!

Thanks!
