### PR TITLE
Fixed crash with dm session store and devise

### DIFF
--- a/lib/dm-rails/session_store.rb
+++ b/lib/dm-rails/session_store.rb
@@ -60,6 +60,10 @@ module Rails
         self.class.session_class.first_or_new(:session_id => sid)
       end
 
+      def destroy(env)
+        find_session(current_session_id(env)).destroy
+      end
+
     end
 
   end


### PR DESCRIPTION
Rails::DataMapper::Session didn't implement destroy, and the inherited version simply crashes.  Devise uses this to clean up old sessions.
