### PR TITLE
Have the db:migrate task call either db:migrate:up or db:autoupgrade

### DIFF
--- a/lib/dm-rails/railties/database.rake
+++ b/lib/dm-rails/railties/database.rake
@@ -75,7 +75,15 @@ namespace :db do
   end
 
   desc 'Migrate the database to the latest version'
-  task :migrate => 'db:migrate:up'
+  task :migrate do
+    migrate_task = if Dir['db/migrate/*.rb'].empty?
+                     'db:autoupgrade'
+                   else
+                     'db:migrate:up'
+                   end
+
+    Rake::Task[migrate_task].invoke
+  end
 
   namespace :sessions do
     desc "Creates the sessions table for DataMapperStore"


### PR DESCRIPTION
Have the db:migrate task call either db:migrate:up (explicit-migrations) or db:autoupgrade (auto-migrations), depending on whether there are migration files in 'db/migrations/'.
- This allows for the db:migrate task to be invoked on dm-rails projects by
  other tasks or deploy scripts.
