### PR TITLE
Fixes a bug in the name... not sure if this breaks something elsewhere!

### DIFF
--- a/lib/dm-rails/session_store.rb
+++ b/lib/dm-rails/session_store.rb
@@ -18,7 +18,7 @@ module Rails
         property :updated_at, DateTime,                    :index => true
 
         def self.name
-          'session'
+          'Session'
         end
 
         def data


### PR DESCRIPTION
Hi,

I was trying to add a relationship on a session to a user. i.e.

```
#app/model/session.rb
require 'dm-rails/session_store'
class Session < Rails::DataMapper::SessionStore::Session
  belongs_to :user, :required => false
end

#config\initializers\session_store.rb
require 'dm-rails/session_store'
Rails::DataMapper::SessionStore.session_class = Session
My::Application.config.session_store Rails::DataMapper::SessionStore
```

But I kept hitting this error: `Cannot find the parent_model User for session in user`

This patch fixes my problem. I'm not sure if this has any unintended side-effects... not sure why `self.name` is overwritten in the first place. Case matters when `DataMapper::Ext::Module.find_const` comes to find the Model class for the belongs_to relationship; not sure if any other code relies on lower case.

Please let me know if I'm going about this the wrong way.

Cheers,
Corin
