### PR TITLE
Forcing version bump for dm-active_model to make use of recently fixed misdependency in dm-active_model

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ DM_DO_ADAPTERS = %w[ sqlite postgres mysql oracle sqlserver ]
 
 gem 'dm-core', DM_VERSION, SOURCE => "#{DATAMAPPER}/dm-core#{REPO_POSTFIX}"
 gem 'actionpack',      '~> 3.0.4', :require => 'action_pack'
-gem 'dm-active_model', '1.1.1', SOURCE => "#{DATAMAPPER}/dm-active_model#{REPO_POSTFIX}", :branch => 'master'
+gem 'dm-active_model', '~> 1.1.1', SOURCE => "#{DATAMAPPER}/dm-active_model#{REPO_POSTFIX}", :branch => 'master'
 gem 'railties',        '~> 3.0.4', :require => 'rails'
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ DM_DO_ADAPTERS = %w[ sqlite postgres mysql oracle sqlserver ]
 
 gem 'dm-core', DM_VERSION, SOURCE => "#{DATAMAPPER}/dm-core#{REPO_POSTFIX}"
 gem 'actionpack',      '~> 3.0.4', :require => 'action_pack'
-gem 'dm-active_model', DM_VERSION, SOURCE => "#{DATAMAPPER}/dm-active_model#{REPO_POSTFIX}"
+gem 'dm-active_model', '~> 1.1.1', SOURCE => "#{DATAMAPPER}/dm-active_model#{REPO_POSTFIX}"
 gem 'railties',        '~> 3.0.4', :require => 'rails'
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ DM_DO_ADAPTERS = %w[ sqlite postgres mysql oracle sqlserver ]
 
 gem 'dm-core', DM_VERSION, SOURCE => "#{DATAMAPPER}/dm-core#{REPO_POSTFIX}"
 gem 'actionpack',      '~> 3.0.4', :require => 'action_pack'
-gem 'dm-active_model', '~> 1.1.1', SOURCE => "#{DATAMAPPER}/dm-active_model#{REPO_POSTFIX}"
+gem 'dm-active_model', '1.1.1', SOURCE => "#{DATAMAPPER}/dm-active_model#{REPO_POSTFIX}"
 gem 'railties',        '~> 3.0.4', :require => 'rails'
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ DM_DO_ADAPTERS = %w[ sqlite postgres mysql oracle sqlserver ]
 
 gem 'dm-core', DM_VERSION, SOURCE => "#{DATAMAPPER}/dm-core#{REPO_POSTFIX}"
 gem 'actionpack',      '~> 3.0.4', :require => 'action_pack'
-gem 'dm-active_model', '1.1.1', SOURCE => "#{DATAMAPPER}/dm-active_model#{REPO_POSTFIX}"
+gem 'dm-active_model', SOURCE => "#{DATAMAPPER}/dm-active_model#{REPO_POSTFIX}", :branch => 'master'
 gem 'railties',        '~> 3.0.4', :require => 'rails'
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ DM_DO_ADAPTERS = %w[ sqlite postgres mysql oracle sqlserver ]
 
 gem 'dm-core', DM_VERSION, SOURCE => "#{DATAMAPPER}/dm-core#{REPO_POSTFIX}"
 gem 'actionpack',      '~> 3.0.4', :require => 'action_pack'
-gem 'dm-active_model', SOURCE => "#{DATAMAPPER}/dm-active_model#{REPO_POSTFIX}", :branch => 'master'
+gem 'dm-active_model', '1.1.1', SOURCE => "#{DATAMAPPER}/dm-active_model#{REPO_POSTFIX}", :branch => 'master'
 gem 'railties',        '~> 3.0.4', :require => 'rails'
 
 group :development do


### PR DESCRIPTION
Forcing version bump for dm-active_model to make use of recently fixed misdependency. See https://github.com/datamapper/dm-active_model/commit/6b49e3ec80e3164c980adf97f27186095fe5d305


cruxst: Hi guys
[5:35pm] cruxst: Quick question: how do I force dm-rails to use the *latest* dm-active_model without forking it and modifying Gemfile?
[5:36pm] cruxst: Reason: invalid dependency has been removed in dm-active_model master branch, but version hasn't been updated. dm-rails therefore fetches a latest version, not master branch of dm-active_model.
[5:37pm] cruxst: snusnu: halp plz
[5:40pm] cruxst: Commit that fixed the problem: https://github.com/datamapper/dm-active_model/commit/6b49e3ec80e3164c980adf97f27186095fe5d305
[5:46pm] solnic left the chat room. (Remote host closed the connection)
[5:57pm] • cruxst is dissapoint no one is responding.