### PR TITLE
Fix incomaptibility with number of arguments in Rails 3.1 vs 3.0

### DIFF
--- a/lib/dm-rails/session_store.rb
+++ b/lib/dm-rails/session_store.rb
@@ -40,7 +40,7 @@ module Rails
         sid ||= generate_sid
         session = find_session(sid)
         env[SESSION_RECORD_KEY] = session
-        [ sid, session.data || {} ]
+        [ sid, session.data ]
       end
 
       def set_session(env, sid, session_data, options = {})


### PR DESCRIPTION
This fixes the session store in Rails 3.1, as reported by this user:

http://stackoverflow.com/questions/7831431/sessions-with-datamapper-dont-work-due-to-an-argumenterror?utm_source=twitterfeed&utm_medium=twitter

We ran into the same issue with our own custom session store and I never thought to check if DM's was affected.  Rails 3.1 passed extra options parameters into some methods in the session store, which cause an ArgumentError.
