### PR TITLE
Update dependencies to support Rails 5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,17 +7,15 @@ gemspec
 SOURCE         = ENV.fetch('SOURCE', :git).to_sym
 REPO_POSTFIX   = SOURCE == :path ? ''                                : '.git'
 DATAMAPPER     = SOURCE == :path ? Pathname(__FILE__).dirname.parent : 'http://github.com/datamapper'
-DM_VERSION     = '~> 1.2.0'
+DM_VERSION     = '~> 1.2'
 DO_VERSION     = '~> 0.10.12'
-RAILS_VERSION  = [ '>= 3.0', '< 5.0' ]
+# RAILS_VERSION  = [ '>= 3.0', '< 5.0' ]
 DM_DO_ADAPTERS = %w[ sqlite postgres mysql oracle sqlserver ]
 CURRENT_BRANCH = ENV.fetch('GIT_BRANCH', 'master')
 
 # DataMapper dependencies
 gem 'dm-core',         DM_VERSION, SOURCE => "#{DATAMAPPER}/dm-core#{REPO_POSTFIX}",         :branch => CURRENT_BRANCH
-gem 'dm-active_model', DM_VERSION, SOURCE => "#{DATAMAPPER}/dm-active_model#{REPO_POSTFIX}", :branch => CURRENT_BRANCH
-
-gem 'protected_attributes'
+gem 'dm-active_model', DM_VERSION, SOURCE => "#{DATAMAPPER}/dm-active_model#{REPO_POSTFIX}", :branch => "rails-5"
 
 platforms :mri_18 do
   group :quality do

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ CURRENT_BRANCH = ENV.fetch('GIT_BRANCH', 'master')
 
 # DataMapper dependencies
 gem 'dm-core',         DM_VERSION, SOURCE => "#{DATAMAPPER}/dm-core#{REPO_POSTFIX}",         :branch => CURRENT_BRANCH
-gem 'dm-active_model', DM_VERSION, SOURCE => "#{DATAMAPPER}/dm-active_model#{REPO_POSTFIX}", :branch => "rails-5"
+gem 'dm-active_model', DM_VERSION, SOURCE => "#{DATAMAPPER}/dm-active_model#{REPO_POSTFIX}", :branch => CURRENT_BRANCH
 
 platforms :mri_18 do
   group :quality do

--- a/README.rdoc
+++ b/README.rdoc
@@ -491,43 +491,6 @@ Field names can be customized in the same manner using `Rails::DataMapper.config
 
 For more detailed documentation about DataMapper naming conventions and the ones that are available by default, have a look at http://rdoc.info/projects/datamapper/dm-core and search for _NamingConventions_ in the Class List.
 
-== Mass assignment protection
-
-By default, `dm-rails` doesn't activate any support for mass assignment protection.
-You can however activate it for your application by including the relevant module
-either globally into all known models, or on a per model basis (the latter being
-advised, for reasons explained below).
-
-  # Global installation (config/application.rb is a good place for adding this)
-  #
-  # Make .attr_protected and .attr_accessible available to all models
-  # NOTE: This won't work if you have code that includes DataMapper::Resource
-  # into any other module. This is done by dm-is-remixable for example, so to
-  # be safe, you should only do that if you really know what you're doing.
-  # Quite some plugins make use of dm-is-remixable, so be sure to check that out
-  # before you go ahead and do the following in your config/application.rb
-  DataMapper::Model.append_inclusions(Rails::DataMapper::MassAssignmentSecurity)
-
-  # Local installation (recommended)
-  #
-  # Include the mass assignment protection only into models that actually need it
-  # This is the preferred way of doing things, at least for now. You will only
-  # have the functionality available where you actually need it, and you don't run
-  # into problems with third party code including DataMapper::Resource into other
-  # modules.
-
-  class Person
-
-    include DataMapper::Resource
-    include DataMapper::MassAssignmentSecurity
-
-    property :id, Serial
-    property :login, String
-
-    attr_protected :login
-
-  end
-
 == Using additional datamapper plugins
 
 In order to use additional plugins add them to the Gemfile and require them from inside a file in config/initializers. Once you've done that, update your bundle and you should be ready to use the plugin(s)

--- a/dm-rails.gemspec
+++ b/dm-rails.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |gem|
   gem.version       = DataMapper::Rails::VERSION
 
   gem.add_runtime_dependency('dm-active_model', '~> 1.2', '>= 1.2.0')
-  gem.add_runtime_dependency('actionpack',      '>= 3.0', '< 5.0')
-  gem.add_runtime_dependency('railties',        '>= 3.0', '< 5.0')
+  gem.add_runtime_dependency('actionpack',      '>= 3.0', '< 6.0')
+  gem.add_runtime_dependency('railties',        '>= 3.0', '< 6.0')
 
   gem.add_development_dependency('rake',      '~> 0.9.2')
   gem.add_development_dependency('rspec',     '~> 1.3.2')


### PR DESCRIPTION
* Remove protected attributes gem, which is not supported by Rails 5 (mass assignement security is still there in code, for people still on Rails 4)
* Slacken DM_VERSION in Gemfile to support DM development on master of v1.3
* Comment out RAILS_VERSION (unused)
* Change dm-active_model to rails-5 branch until merge and release there
